### PR TITLE
increased stylus version to remove security warning from npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-stylus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Express middleware for Stylus",
   "license": "MIT",
   "author": {
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/dogancelik/express-stylus",
   "dependencies": {
     "debug": "^2.2.0",
-    "stylus": "^0.52.0"
+    "stylus": "^0.54.5"
   },
   "devDependencies": {
     "nib": "^1.1.0",


### PR DESCRIPTION
```npm audit``` gives the following error. The issue has been resolved in stylus and it's dependent packages.

```
  High            Regular Expression Denial of Service

  Package         minimatch

  Patched in      >=3.0.2

  Dependency of   express-stylus

  Path            express-stylus > stylus > glob > minimatch

  More info       https://npmjs.com/advisories/118
```

I ran ```npm run test``` against it and it passed. With the stylus i have, it seems to be working correctly after the upgrade.